### PR TITLE
Add geocoder to search

### DIFF
--- a/source/css/_base_theme.scss
+++ b/source/css/_base_theme.scss
@@ -1,9 +1,7 @@
 body {
   color: $bodytext-black;
   font-family: $base-sans-serif;
-  -moz-osx-font-smoothing: grayscale;
   line-height: 1;
-  text-rendering: optimizelegibility;
 }
 
 a {
@@ -49,7 +47,6 @@ button,
   display: inline-block;
   font-family: $base-sans-serif;
   letter-spacing: .03rem;
-  vertical-align: middle;
   @include button(flat, $tribune-yellow);
 
   &:disabled {

--- a/source/css/_theme.scss
+++ b/source/css/_theme.scss
@@ -174,6 +174,7 @@ p.glossary-text {
   }
 
   .form-prompt {
+    display: block;
     font-size: .875em;
     font-style: italic;
     margin: 0 0 .5em;
@@ -219,17 +220,15 @@ p.glossary-text {
   }
 
   input {
-    -webkit-appearance: none;
     border: 1px solid rgb(204, 204, 204);
-    border-radius: 3px;
+    border-radius: 4px;
     font-size: 1em;
-    height: 30px;
     margin: 0;
-    padding: 7px 10px;
+    padding: 4px 10px;
     width: 100%;
 
     @include media($desktop) {
-      width: 300px;
+      width: 400px;
     }
   }
 

--- a/source/css/_theme.scss
+++ b/source/css/_theme.scss
@@ -189,7 +189,7 @@ p.glossary-text {
   .or-separator {
     display: block;
     font-weight: 800;
-    margin: 1em 0;
+    margin: .5em 0;
 
     @include media($desktop) {
       display: inline;
@@ -229,11 +229,12 @@ p.glossary-text {
     border: 1px solid rgb(204, 204, 204);
     border-radius: 4px;
     font-size: 1em;
-    margin: 0;
+    margin: 0 0 1em;
     padding: 4px 10px;
     width: 100%;
 
     @include media($desktop) {
+      margin: 0;
       width: 400px;
     }
   }

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -32,7 +32,7 @@ title: Texas Hospitals Explorer | The Texas Tribune
   <div class="content-block content-block-full introduction-section">
   </div>
   <div class="content-block call-to-action">
-    <p>Search for hospitals near you or enter a Texas ZIP code to look up quality-of-care measures for any hospital in the state. Use the search to find information about a specific hospital, or find and select multiple hospitals to compare.</p>
+    <p>Search for hospitals near you to look up quality-of-care measures for any hospital in the state. Find information about a specific hospital, or find and select multiple hospitals to compare.</p>
   </div>
   <div class="loading" style="text-align:center;">
     <img src="/img/ajax-loader.gif">

--- a/source/js/controllers/search_controller.js
+++ b/source/js/controllers/search_controller.js
@@ -64,20 +64,6 @@ app.Controllers.SearchController = Marionette.Controller.extend({
     });
   },
 
-  searchByName: function(name, page) {
-    var regex = new RegExp(name, 'i'),
-        results;
-
-    results = app.hospitals.filter(function(hospital) {
-      if(hospital.get('name').toLowerCase().search(regex) !== -1){
-        return hospital;
-      }
-    });
-    this.center = [];
-    results = results.slice((page - 1) * this.perPage, page * this.perPage);
-    this.trigger('around:search', results);
-  },
-
   searchByLocation: function(page) {
     var self = this,
         locationFound,

--- a/source/js/templates/search-template.jst.ejs
+++ b/source/js/templates/search-template.jst.ejs
@@ -1,16 +1,15 @@
 <form>
-  <p class="form-prompt">Search by hospital name or ZIP code</p>
   <div class="form-group">
-    <label class="sr-only" for="search-content">Search by hospital name or ZIP code</label>
-    <input type="text" id="search-content" placeholder="78701">
-  </div>
+    <label class="form-prompt" for="search-content">Search by address</label>
+    <input type="text" id="search-content" placeholder="E.g. 823 Congress Ave, Austin, TX 78701">
   <button id="search-submit" class="search-submit" type="submit">Search</button>
   <span class="or-separator">- or -</span>
   <button id="find-me" class="find-me">Find hospitals near you</button>
   <img src="/img/round-ajax-loader.gif" class="loading hide"/>
+  </div>
 </form>
 <a id="view-all" class="view-all">View all hospitals</a>
 <div class="messages">
   <div class="error hide"></div>
-  <div class='empty hide'>We couldn't find any hospitals, please try again</div>
+  <div class='empty hide'>No hospitals were found - please try again</div>
 </div>

--- a/source/js/views/search_view.js
+++ b/source/js/views/search_view.js
@@ -30,7 +30,7 @@ app.Views.Search = Marionette.ItemView.extend({
     this.cleanView();
     if (cad === ''){
       // TODO: find a better message
-      this.showError('Please type a Zipcode or a Hospital Name');
+      this.showError('Please provide an address');
     } else {
       this.trigger("call:search", cad);
     }


### PR DESCRIPTION
So I added a full on geocoder to the hospital search.

![screen shot 2015-01-28 at 6 58 30 pm](https://cloud.githubusercontent.com/assets/419145/5950433/b3543318-a71f-11e4-8b70-502ea79db173.png)

No more ZIP Code hoops! \o/

I also cleaned up some of the language around the errors. One side effect – this does kill the ability to search by hospital name. But I believe the "View All Hospitals" fills that role effectively. I think there is a bigger boon to being able to type anything address-like into that field and find something.